### PR TITLE
[WIP] rfc2217esp

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -60,6 +60,8 @@ except ImportError:
           "Check the README for installation instructions." % (sys.VERSION, sys.executable))
     raise
 
+import rfc2217esp
+
 __version__ = "2.6"
 
 MAX_UINT32 = 0xffffffff
@@ -414,7 +416,7 @@ class ESPLoader(object):
         #
         # DTR & RTS are active low signals,
         # ie True = pin @ 0V, False = pin @ VCC.
-        if mode != 'no_reset':
+        if mode != 'no_reset' or mode != 'flush_esp':
             self._setDTR(False)  # IO0=HIGH
             self._setRTS(True)   # EN=LOW, chip in reset
             time.sleep(0.1)
@@ -432,6 +434,10 @@ class ESPLoader(object):
                 time.sleep(0.4)  # allow watchdog reset to occur
             time.sleep(0.05)
             self._setDTR(False)  # IO0=HIGH, done
+
+        # For rfc2217esp://...
+        if mode == 'flush_esp':
+            self._port.flash_esp()
 
         for _ in range(5):
             try:
@@ -2420,7 +2426,7 @@ def main(custom_commandline=None):
     parser.add_argument(
         '--before',
         help='What to do before connecting to the chip',
-        choices=['default_reset', 'no_reset', 'no_reset_no_sync'],
+        choices=['default_reset', 'no_reset', 'no_reset_no_sync', 'flush_esp'],
         default=os.environ.get('ESPTOOL_BEFORE', 'default_reset'))
 
     parser.add_argument(

--- a/rfc2217_server_esp.py
+++ b/rfc2217_server_esp.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+#
+# redirect data from a TCP/IP connection to a serial port and vice versa
+# using RFC 2217
+#
+# (C) 2009-2015 Chris Liechti <cliechti@gmx.net>
+#
+# SPDX-License-Identifier:    BSD-3-Clause
+
+import logging
+import socket
+import sys
+import time
+import threading
+import serial
+import rfc2217esp
+
+
+class Redirector(object):
+    def __init__(self, serial_instance, socket, debug=False):
+        self.serial = serial_instance
+        self.socket = socket
+        self._write_lock = threading.Lock()
+        self.rfc2217 = rfc2217esp.PortManager(
+            self.serial,
+            self,
+            logger=logging.getLogger('rfc2217.server') if debug else None)
+        self.log = logging.getLogger('redirector')
+
+    def statusline_poller(self):
+        self.log.debug('status line poll thread started')
+        while self.alive:
+            time.sleep(1)
+            self.rfc2217.check_modem_lines()
+        self.log.debug('status line poll thread terminated')
+
+    def shortcircuit(self):
+        """connect the serial port to the TCP port by copying everything
+           from one side to the other"""
+        self.alive = True
+        self.thread_read = threading.Thread(target=self.reader)
+        self.thread_read.daemon = True
+        self.thread_read.name = 'serial->socket'
+        self.thread_read.start()
+        self.thread_poll = threading.Thread(target=self.statusline_poller)
+        self.thread_poll.daemon = True
+        self.thread_poll.name = 'status line poll'
+        self.thread_poll.start()
+        self.writer()
+
+    def reader(self):
+        """loop forever and copy serial->socket"""
+        self.log.debug('reader thread started')
+        while self.alive:
+            try:
+                data = self.serial.read(self.serial.in_waiting or 1)
+                if data:
+                    # escape outgoing data when needed (Telnet IAC (0xff) character)
+                    self.write(b''.join(self.rfc2217.escape(data)))
+            except socket.error as msg:
+                self.log.error('{}'.format(msg))
+                # probably got disconnected
+                break
+        self.alive = False
+        self.log.debug('reader thread terminated')
+
+    def write(self, data):
+        """thread safe socket write with no data escaping. used to send telnet stuff"""
+        with self._write_lock:
+            self.socket.sendall(data)
+
+    def writer(self):
+        """loop forever and copy socket->serial"""
+        while self.alive:
+            try:
+                data = self.socket.recv(1024)
+                if not data:
+                    break
+                self.serial.write(b''.join(self.rfc2217.filter(data)))
+            except socket.error as msg:
+                self.log.error('{}'.format(msg))
+                # probably got disconnected
+                break
+        self.stop()
+
+    def stop(self):
+        """Stop copying"""
+        self.log.debug('stopping')
+        if self.alive:
+            self.alive = False
+            self.thread_read.join()
+            self.thread_poll.join()
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="RFC 2217 Serial to Network (TCP/IP) redirector.",
+        epilog="""\
+NOTE: no security measures are implemented. Anyone can remotely connect
+to this service over the network.
+
+Only one connection at once is supported. When the connection is terminated
+it waits for the next connect.
+""")
+
+    parser.add_argument('SERIALPORT')
+
+    parser.add_argument(
+        '-p', '--localport',
+        type=int,
+        help='local TCP port, default: %(default)s',
+        metavar='TCPPORT',
+        default=2217)
+
+    parser.add_argument(
+        '-v', '--verbose',
+        dest='verbosity',
+        action='count',
+        help='print more diagnostic messages (option can be given multiple times)',
+        default=0)
+
+    args = parser.parse_args()
+
+    if args.verbosity > 3:
+        args.verbosity = 3
+    level = (logging.WARNING,
+             logging.INFO,
+             logging.DEBUG,
+             logging.NOTSET)[args.verbosity]
+    logging.basicConfig(format='%(asctime)s %(levelname)s:%(name)s:%(message)s', level=logging.INFO)
+
+    #~ logging.getLogger('root').setLevel(logging.INFO)
+    logging.getLogger('rfc2217').setLevel(level)
+
+    # connect to serial port
+    ser = serial.serial_for_url(args.SERIALPORT, do_not_open=True)
+    ser.timeout = 3     # required so that the reader thread can exit
+    # reset control line as no _remote_ "terminal" has been connected yet
+    ser.dtr = False
+    ser.rts = False
+
+    logging.info("RFC 2217 TCP/IP to Serial redirector - type Ctrl-C / BREAK to quit")
+
+    try:
+        ser.open()
+    except serial.SerialException as e:
+        logging.error("Could not open serial port {}: {}".format(ser.name, e))
+        sys.exit(1)
+
+    logging.info("Serving serial port: {}".format(ser.name))
+    settings = ser.get_settings()
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(('', args.localport))
+    srv.listen(1)
+    logging.info("TCP/IP port: {}".format(args.localport))
+    while True:
+        try:
+            client_socket, addr = srv.accept()
+            logging.info('Connected by {}:{}'.format(addr[0], addr[1]))
+            client_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            ser.rts = True
+            ser.dtr = True
+            # enter network <-> serial loop
+            r = Redirector(
+                ser,
+                client_socket,
+                args.verbosity > 0)
+            try:
+                r.shortcircuit()
+            finally:
+                logging.info('Disconnected')
+                r.stop()
+                client_socket.close()
+                ser.dtr = False
+                ser.rts = False
+                # Restore port settings (may have been changed by RFC 2217
+                # capable client)
+                ser.apply_settings(settings)
+        except KeyboardInterrupt:
+            sys.stdout.write('\n')
+            break
+        except socket.error as msg:
+            logging.error(str(msg))
+
+    logging.info('--- exit ---')

--- a/rfc2217esp/__init__.py
+++ b/rfc2217esp/__init__.py
@@ -1,0 +1,6 @@
+import serial
+
+from .portmanager import PortManager
+
+serial.protocol_handler_packages.remove("serial.urlhandler")
+serial.protocol_handler_packages.append("rfc2217esp.urlhandler")

--- a/rfc2217esp/portmanager.py
+++ b/rfc2217esp/portmanager.py
@@ -1,0 +1,36 @@
+import serial.rfc2217
+import time
+
+PURGE_FLASH = b'\x07' # Set the ESP in flash mode
+
+class PortManager(serial.rfc2217.PortManager):
+
+    def __init__(self, serial_port, connection, logger=None):
+        super(PortManager, self).__init__(serial_port, connection, logger)
+
+    def _setDTR(self, state):
+        self.serial.setDTR(state)
+
+    def _setRTS(self, state):
+        self.serial.setRTS(state)
+        # Work-around for adapters on Windows using the usbser.sys driver:
+        # generate a dummy change to DTR so that the set-control-line-state
+        # request is sent with the updated RTS state and the same DTR state
+        self.serial.setDTR(self.serial.dtr)
+
+    def _telnet_process_subnegotiation(self, suboption):
+        if suboption[0:1] == serial.rfc2217.COM_PORT_OPTION and suboption[1:2] == serial.rfc2217.PURGE_DATA and suboption[2:3] == PURGE_FLASH:
+            if self.logger:
+                self.logger.info("Set ESP to flash mode")
+
+            self._setDTR(False)  # IO0=HIGH
+            self._setRTS(True)   # EN=LOW, chip in reset
+            time.sleep(0.1)
+            self._setDTR(True)   # IO0=LOW
+            self._setRTS(False)  # EN=HIGH, chip out of reset
+            time.sleep(0.05)
+            self._setDTR(False)  # IO0=HIGH, done
+
+            self.rfc2217_send_subnegotiation(serial.rfc2217.SERVER_PURGE_DATA, PURGE_FLASH)
+        else:
+            super(PortManager, self)._telnet_process_subnegotiation(suboption)

--- a/rfc2217esp/urlhandler/protocol_rfc2217.py
+++ b/rfc2217esp/urlhandler/protocol_rfc2217.py
@@ -1,0 +1,13 @@
+import serial.rfc2217
+
+PURGE_FLASH = b'\x07' # Set the ESP in flash mode
+
+class Serial(serial.rfc2217.Serial):
+
+    def __init__(self, *args, **kwargs):
+        super(Serial, self).__init__(*args, **kwargs)
+
+    def flash_esp(self):
+        if not self.is_open:
+            raise portNotOpenError
+        self.rfc2217_send_purge(PURGE_FLASH)


### PR DESCRIPTION
# Description of change
Use serial port over network.
https://github.com/espressif/esptool/issues/383

# I have tested this change with the following hardware & software combinations:
Ubuntu 18.4 in Docker
macOS Mojave
M5StickC

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

not yet.

(Details here: https://github.com/espressif/esptool/blob/master/CONTRIBUTING.md#automated-integration-tests )


```
# Dockerにesp-idf開発環境をつくる
(host)# git clone git@github.com:shungok/esp32-cmake-development-env.git
(host)# cd esp32-cmake-development-env
(host)# cat Dockerfile | docker build - -t esp32-idf-v3.2.2 --build-arg ESP_IDF_VERSION=v3.2.2
(host)# docker run -v `pwd`/esp-project:/esp/project -it --name esp-idf-dev esp32-idf-v3.2.2
(host)# docker start esp-idf-dev

# esptoolをrfc2217esp対応版に差し替える
(host)# docker exec -it esp-idf-dev bash
(container)# cd /opt/local/esp/esp-idf/components/esptool_py/esptool
(container)# git remote add takeru https://github.com/takeru/esptool.git
(container)# git fetch takeru
(container)# git checkout takeru/rfc2217esp

# Macにrfc2217_server_esp.pyを準備
(mac)% git clone -b rfc2217esp https://github.com/takeru/esptool.git
(mac)% cd esptool
(mac)% pip install pyserial
(mac)% IPADDR=`ifconfig en0 inet | ruby -e 'puts STDIN.read[/inet (192\.168\.\d+\.\d+)/, 1]'` && echo $IPADDR
192.168.0.129
(mac)% python rfc2217_server_esp.py -p 9999 `ls -1 /dev/tty.usbserial-*` -v -v -v

# M5StickCのプロジェクト
(container)# cd /esp/project/
(container)# git clone https://github.com/yishii/M5StickC-IDF.git
(container)# cd M5StickC-IDF
(container)# make menuconfig # => Set serial port "rfc2217://192.168.0.129:9999"
(container)# make
(container)# make flash

# TODO
- --baud 1500000
```
